### PR TITLE
Fix for #23 Allow to select edit boxes

### DIFF
--- a/src/Canopy.Mobile/Canopy.Mobile.fs
+++ b/src/Canopy.Mobile/Canopy.Mobile.fs
@@ -173,7 +173,7 @@ let tryFind selector = findAllBy (toBy selector)
 /// Returns true when the selector matches an element on the current page or otherwise false.
 let exists selector = 
     try
-        findElementsBy (toBy selector) true 0. |> List.isEmpty |> not
+        findElementsBy (toBy selector) true 1.0 |> List.isEmpty |> not
     with
     | _ -> false
 

--- a/src/Canopy.Mobile/Selectors.fs
+++ b/src/Canopy.Mobile/Selectors.fs
@@ -4,7 +4,7 @@ module canopy.mobile.selectors
 /// Selector conventions that determine if a selector matches a pattern and if it does what the resulting By is
 let mutable selectorConventions =
     [
-        fun (selector : string) -> if selector.StartsWith("#") then Some (OpenQA.Selenium.By.Id(selector.Replace("#", "android:id/"))) else None
+        fun (selector : string) -> if selector.StartsWith("#") then Some (OpenQA.Selenium.By.XPath(sprintf """//*[contains(@resource-id, ':id/%s')]""" (selector.Replace("#", "")))) else None
         fun (selector : string) -> if selector.StartsWith("tv:") then Some (OpenQA.Selenium.By.XPath(sprintf """//android.widget.TextView[@text="%s"]""" (selector.Replace("tv:", "")))) else None
         fun (selector : string) -> if selector.StartsWith("edit:") then Some (OpenQA.Selenium.By.XPath(sprintf """//android.widget.EditText[@text="%s"]""" (selector.Replace("edit:", "")))) else None
         fun (selector : string) -> if selector.StartsWith("menu-tv:") then Some (OpenQA.Selenium.By.XPath(sprintf """//android.widget.TextView[@content-desc="%s"]""" (selector.Replace("menu-tv:", "")))) else None


### PR DESCRIPTION
2 things:
First the timeout on `exists` was set to 0, which makes sense but does not actually work.  I bumped it to 1.0, maybe 0.1 will work, not sure, but 0.0 does not work at expected.

The other part was that the selector you wanted was an `id` but it was not an `android:id`.  It was an `io.appium.android.apis:id` so I adjusted the selector to be less specific. 

Unfortunately appium does not support XPath 2.0 or I could have used ends-with instead I cheesed it with contains, which is not technically correct but 'good enough' I hope.